### PR TITLE
Linking pages together in r10 & r11 prototype

### DIFF
--- a/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-application-2-new.html
+++ b/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-application-2-new.html
@@ -19,7 +19,7 @@
 
 <div class="nhsuk-back-link">
 
-  <a class="nhsuk-back-link__link" href="../dashboard-update-option-1-mvp/manage-live">
+  <a class="nhsuk-back-link__link" href="manage-live-reviewed">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="24" width="24">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>
@@ -32,7 +32,7 @@
 <div class="nhsuk-grid-column-full">
 
   <h1 class="nhsuk-u-margin-bottom-3"> <span class="nhsuk-caption-l">Reference number: V-5r4-2WB</span style="text-align: center;"> Walk and talk volunteer application <span class="nhsuk-tag nhsuk-tag--green">New</span></h1>
-  <p class="nhsuk-body"><strong>Date received:</strong> 24 February 2025</p>
+  <p class="nhsuk-body"><strong>Date received:</strong> 12 February 2025</p>
 
   <div class="govuk-warning-text nhsuk-u-margin-bottom-5">
     <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
@@ -145,11 +145,14 @@
   </dl>
 
 
-   <div class="nhsapp-button-group">
 
-    <a href="changing-status-flow/manage-application-1-reviewed" class="nhsuk-button nhsuk-button--primary">Mark as reviewed</a>
+<div class="nhsapp-button-group">
+
+    <a href="" class="nhsuk-button nhsuk-button--primary">Mark as reviewed</a>
     <a href="#" class="nhsuk-button nhsuk-button--secondary">Print this page</a>
   </div>
+  </div>
+
 
 </div>
 </div>

--- a/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-live-archived-2.html
+++ b/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-live-archived-2.html
@@ -93,7 +93,7 @@
           </tr>
         </thead>
       <tbody>
-          <tr><td>REF-004</td><td>12 February 2025</td><td>17 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td><td><a href ="../changing-status-flow/manage-application-1-reviewed.html">View application</a></td></tr>
+          <tr><td>REF-004</td><td>12 February 2025</td><td>17 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td><td><a href ="manage-application-1-reviewed">View application</a></td></tr>
           <tr><td>REF-035</td><td>13 May 2025</td><td>15 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td><td><a href="">View application</a></td></tr>
           <tr><td>REF-034</td><td>12 May 2025</td><td>14 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td><td><a href="../dashboard-update-option-1-mvp/manage-application-2">View application</a></td></tr>
           <tr><td>REF-033</td><td>11 May 2025</td><td>14 May 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td><td><a href="../dashboard-update-option-1-mvp/manage-application-3">View application</a></td></tr>

--- a/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-live-reviewed.html
+++ b/app/views/r10/dashboard-update-option-1-mvp/changing-status-flow/manage-live-reviewed.html
@@ -88,7 +88,7 @@
           </tr>
         </thead>
       <tbody>
-          <tr><td>REF-005</td><td>12 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td><td><a href="manage-application-1-reviewed">View application</a></td></tr>
+          <tr><td>REF-005</td><td>12 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td><td><a href="manage-application-2-new">View application</a></td></tr>
           <tr><td>REF-006</td><td>11 May 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td><td><a href="">View application</a></td></tr>
           <tr><td>REF-007</td><td>10 July 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td><td><a href="">View application</a></td></tr>
           <tr><td>REF-008</td><td>12 July 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td><td><a href="">View application</a></td></tr>

--- a/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-application-2.html
+++ b/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-application-2.html
@@ -19,7 +19,7 @@
 
 <div class="nhsuk-back-link">
 
-  <a class="nhsuk-back-link__link" href="../dashboard-update-option-1-mvp/manage-live">
+  <a class="nhsuk-back-link__link" href="manage-live-reviewed">
     <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" height="24" width="24">
       <path d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z"></path>
     </svg>
@@ -150,6 +150,7 @@
     <a href="changing-status-flow/manage-application-1-reviewed" class="nhsuk-button nhsuk-button--primary">Mark as reviewed</a>
     <a href="#" class="nhsuk-button nhsuk-button--secondary">Print this page</a>
   </div>
+
 
 </div>
 </div>

--- a/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-live-archived-2.html
+++ b/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-live-archived-2.html
@@ -92,7 +92,7 @@
           </tr>
         </thead>
       <tbody>
-          <tr><td><a href="../dashboard-update-option-1-mvp/changing-status-flow/manage-application-1-reviewed">John Doe</a></td><td>REF-004</td><td>12 August 2025</td><td>17 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td></tr>
+          <tr><td><a href="manage-application-1-reviewed">John Doe</a></td><td>REF-004</td><td>12 August 2025</td><td>17 August 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td></tr>
           <tr><td><a href="../dashboard-update-option-1-mvp/manage-application-1">[Name]</a></td><td>REF-035</td><td>13 May 2025</td><td>16 May 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td></tr>
           <tr><td><a href="../dashboard-update-option-1-mvp/manage-application-2">[Name]</a></td><td>REF-034</td><td>12 May 2025</td><td>14 May 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td></tr>
           <tr><td><a href="../dashboard-update-option-1-mvp/manage-application-3">[Name]</a></td><td>REF-033</td><td>11 May 2025</td><td>14 May 2025</td><td><span class="nhsuk-tag nhsuk-tag--grey">Reviewed</span></td></tr>

--- a/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-live-reviewed.html
+++ b/app/views/r11/dashboard-update-option-1-mvp/changing-status-flow/manage-live-reviewed.html
@@ -88,7 +88,7 @@
           </tr>
         </thead>
       <tbody>
-          <tr><td><a href="manage-application-2-reviewed">Mark Foster</a></td><td>REF-005</td><td>12 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td></tr>
+          <tr><td><a href="manage-application-2">Mark Foster</a></td><td>REF-005</td><td>12 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td></tr>
           <tr><td><a href="">Emma Carter</a></td><td>REF-006</td><td>11 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td></tr>
           <tr><td><a href="">Daniel Wilson</a></td><td>REF-007</td><td>10 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td></tr>
           <tr><td><a href="">Olivia Scott</a></td><td>REF-008</td><td>09 February 2025</td><td><span class="nhsuk-tag nhsuk-tag--green">New</span></td></tr>


### PR DESCRIPTION
Fixed broken links to pages to applications after 'mark as reviewed' when reviewing in the table 'new' and 'reviewed' pages, the links were broken and did not link out to pages. Have now resolved this issue. 
