### PR TITLE
revert homepage heading test change

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -31,7 +31,7 @@ NHS Volunteering
 
     <!-- Change the page title here -->
     <h1>
-      NHS volunteering Beta prototype - TEST AQIB
+      NHS volunteering Beta prototype
       <span class="nhsuk-caption-xl nhsuk-caption--bottom">Version 1.0.0</span>
     </h1>
 


### PR DESCRIPTION
Reverts the homepage h1 back to "NHS volunteering Beta prototype", removing the TEST AQIB text added while verifying the push/PR pipeline.