### PR TITLE
Add clear data link to footer layouts

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -84,6 +84,9 @@
             <li class="nhsuk-footer__list-item">
               <a class="nhsuk-footer__list-item-link" href="/v9/index-cookies">Cookies</a>
             </li>
+            <li class="nhsuk-footer__list-item">
+              <a class="nhsuk-footer__list-item-link" href="/prototype-admin/reset">Clear data</a>
+            </li>
           </ul>
           <ul class="nhsuk-footer__list">
             <li class="nhsuk-footer__list-item">

--- a/app/views/layout_vol_header.html
+++ b/app/views/layout_vol_header.html
@@ -74,6 +74,9 @@ NHS Volunteering
           <li class="nhsuk-footer__list-item">
             <a class="nhsuk-footer__list-item-link" href="/v9/index-cookies">Cookies</a>
           </li>
+          <li class="nhsuk-footer__list-item">
+            <a class="nhsuk-footer__list-item-link" href="/prototype-admin/reset">Clear data</a>
+          </li>
         </ul>
         <ul class="nhsuk-footer__list-item">
           <a class="nhsuk-footer__list-item-link"

--- a/app/views/v25/v25_layout.html
+++ b/app/views/v25/v25_layout.html
@@ -84,6 +84,9 @@
             <li class="nhsuk-footer__list-item">
               <a class="nhsuk-footer__list-item-link" href="/v9/index-cookies">Cookies</a>
             </li>
+            <li class="nhsuk-footer__list-item">
+              <a class="nhsuk-footer__list-item-link" href="/prototype-admin/reset">Clear data</a>
+            </li>
           </ul>
           <ul class="nhsuk-footer__list">
             <li class="nhsuk-footer__list-item">

--- a/app/views/v25/v25_layout_vol_header.html
+++ b/app/views/v25/v25_layout_vol_header.html
@@ -75,6 +75,9 @@ NHS Volunteering
           <li class="nhsuk-footer__list-item">
             <a class="nhsuk-footer__list-item-link" href="/v9/index-cookies">Cookies</a>
           </li>
+          <li class="nhsuk-footer__list-item">
+            <a class="nhsuk-footer__list-item-link" href="/prototype-admin/reset">Clear data</a>
+          </li>
         </ul>
         <ul class="nhsuk-footer__list-item">
           <a class="nhsuk-footer__list-item-link"


### PR DESCRIPTION
Adds a Clear data footer link to the prototype layouts, pointing at the kit's session reset. Useful for demos and testing.