### PR TITLE
Remove duplicate v25 results page link from sub-index

### DIFF
--- a/app/views/sub-index-in-development.html
+++ b/app/views/sub-index-in-development.html
@@ -66,8 +66,6 @@ NHS Volunteering
       results count [K5] & [K3]</a></p>
 </div>
 
-<p class="nhsuk-body"><a href="/v25/results/results">V25: Results page - working filters [K5]</a></p>
-
 <p><strong>Q1</strong></p>
 
 <p class="nhsuk-body"><a href="/v24/volunteering/index">V24: This prototype contains all the changes from Q1</a></p>


### PR DESCRIPTION
The direct link to the v25 results page duplicated the journey already covered by the V25 recent prototype entry (filters and tags redesign and results count), which reaches the same working-filters results page via postcode search.