### PR TITLE
Hide distance from selected filters when setting is remote only

### DIFF
--- a/app/views/v25/results/results.html
+++ b/app/views/v25/results/results.html
@@ -167,6 +167,11 @@ NHS Volunteering
 
                 </div>
 
+                {# Distance is hidden when the setting filter is remote-only — it does not
+                   apply to remote opportunities, so showing it here would contradict the
+                   result set. It reappears as soon as the remote tag is removed. #}
+                {% set remoteOnlySetting = settingSelected.length == 1 and "remote" in settingSelected %}
+                {% if not remoteOnlySetting %}
                 <h3 class="nhsuk-heading-s nhsuk-u-margin-bottom-0">Distance</h3>
                 {% if distanceValue != "5" %}
                 <ul class="moj-filter-tags">
@@ -176,6 +181,7 @@ NHS Volunteering
                 </ul>
                 {% else %}
                 <p class="nhsuk-body-s nhsuk-u-margin-top-1 nhsuk-u-margin-bottom-0">{{ distanceLabels[distanceValue] }}</p>
+                {% endif %}
                 {% endif %}
 
                 {% if settingSelected.length %}


### PR DESCRIPTION
When the volunteer setting filter is remote-only, the Distance entry in the Selected filters box contradicted the remote-only result set, so it is now hidden in that state. It reappears as soon as the remote tag is removed or another setting is selected, and a chosen distance value is preserved in the radios throughout. Distance still shows whenever it can affect the results, including zero-result states. Completes the remote-versus-distance work from #422 and #423.