### PR TITLE
Remove distance hint text pending decision on remote in upfront search

### DIFF
--- a/app/views/v25/results/results.html
+++ b/app/views/v25/results/results.html
@@ -250,9 +250,8 @@ NHS Volunteering
                 <p class="nhsuk-hint" id="v25-filter-hint">Select all that apply</p>
 
                 <div class="govuk-form-group">
-                  <fieldset class="govuk-fieldset" aria-describedby="v25-filter-distance-hint">
+                  <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Distance</legend>
-                    <p class="nhsuk-hint" id="v25-filter-distance-hint">Distance does not apply to remote opportunities</p>
                     <div class="govuk-radios govuk-radios--small">
                       {% for value, label in distanceLabels %}
                       <div class="govuk-radios__item">


### PR DESCRIPTION
Removes the "Distance does not apply to remote opportunities" hint under the Distance legend (added in #423) along with its aria-describedby wiring, following stakeholder feedback that the hint may be unnecessary if remote moves into the upfront search. The other remote-only states (hidden sort line, Distance suppressed in Selected filters, unchecked radios) are unchanged.