### PR TITLE
Order in development prototypes by latest quarter first

### DIFF
--- a/app/views/sub-index-in-development.html
+++ b/app/views/sub-index-in-development.html
@@ -66,16 +66,16 @@ NHS Volunteering
       results count [K5] & [K3]</a></p>
 </div>
 
+<p><strong>Q2</strong></p>
+<p class="nhsuk-body"><a href="/v23/index-results">V23: Zero closest results & character count - post content testing
+    [H8] & [H9]</a></p>
+
 <p><strong>Q1</strong></p>
 
 <p class="nhsuk-body"><a href="/v24/volunteering/index">V24: This prototype contains all the changes from Q1</a></p>
 <p class="nhsuk-body"><a href="/v18/index">V18: Post content review updates [J23]</a></p>
 <p class="nhsuk-body"><a href="/v19/index-page">V19: EDI - post usability testing [J8]</a></p>
 <p class="nhsuk-body"><a href="/v19/terms-index-page">V19: T's & C's updates [J30]</a></p>
-
-<p><strong>Q2</strong></p>
-<p class="nhsuk-body"><a href="/v23/index-results">V23: Zero closest results & character count - post content testing
-    [H8] & [H9]</a></p>
 
 
 
@@ -87,6 +87,14 @@ NHS Volunteering
 
 <hr>
 <h3>Recruiter</h3>
+
+<p><strong>Q2</strong></p>
+<p class="nhsuk-body"><a href="/r18/index">R18: V2 Multi factor authentication - content & usability testing
+    [H7]</a>
+</p>
+<p class="nhsuk-body"><a href="/r19/questions/summary">R19: Character count increase to summary page - post testing
+    [H9]</a>
+</p>
 
 <p><strong>Q1</strong></p>
 
@@ -111,15 +119,6 @@ NHS Volunteering
 <p class="nhsuk-body"><a href="/r16/print-preview-update">R16: Changes to print preview, as part of J8 - post
     usability
     testing [J8]</a></p>
-
-
-<p><strong>Q2</strong></p>
-<p class="nhsuk-body"><a href="/r18/index">R18: V2 Multi factor authentication - content & usability testing
-    [H7]</a>
-</p>
-<p class="nhsuk-body"><a href="/r19/questions/summary">R19: Character count increase to summary page - post testing
-    [H9]</a>
-</p>
 </div>
 </div>
 


### PR DESCRIPTION
Order in development prototypes by latest quarter first

Reorders the quarter groupings on the "In development prototypes" sub-index so the most recent quarter appears at the top of each section.

Volunteer: Q3 → Q2 → Q1
Recruiter: Q2 → Q1
Link text and destinations are unchanged, only the order of the quarter blocks.