### PR TITLE
Add pre-application questions to the V25 volunteer journey

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -1494,3 +1494,74 @@ router.get('/v25/results/results', function (req, res) {
     }
   })
 })
+
+// ROUTES FOR V25 pre-application questions
+// Volunteer answers the questions the recruiter selected in the r20
+// pre-application task, in the same session. Any "no" stops the application;
+// "yes" continues to the next selected question, or the application start
+// page once none are left. If the recruiter journey hasn't been done in this
+// session, all 3 questions ask with fallback values.
+
+function v25NextPreApplicationPage(data, current) {
+
+  let selected = data['r20-pre-application-questions']
+  if (selected === undefined) {
+    selected = ['age', 'licence', 'distance']
+  }
+  if (!Array.isArray(selected)) {
+    selected = [selected]
+  }
+
+  const order = ['age', 'licence', 'distance']
+  const pages = {
+    'age': '/v25/pre-application/age',
+    'licence': '/v25/pre-application/driving-licence',
+    'distance': '/v25/pre-application/distance'
+  }
+
+  for (const question of order.slice(order.indexOf(current) + 1)) {
+    if (selected.includes(question)) {
+      return pages[question]
+    }
+  }
+  return '/v25/application/start'
+}
+
+router.post('/v25/pre-application/age', function (req, res) {
+  const answer = req.session.data['v25-pre-application-age']
+
+  if (answer === 'yes') {
+    res.redirect(v25NextPreApplicationPage(req.session.data, 'age'))
+  } else if (answer === 'no') {
+    res.redirect('/v25/pre-application/stopped')
+  } else {
+    // Handle the case where no selection was made (e.g., reload page)
+    res.redirect('/v25/pre-application/age')
+  }
+})
+
+router.post('/v25/pre-application/driving-licence', function (req, res) {
+  const answer = req.session.data['v25-pre-application-licence']
+
+  if (answer === 'yes') {
+    res.redirect(v25NextPreApplicationPage(req.session.data, 'licence'))
+  } else if (answer === 'no') {
+    res.redirect('/v25/pre-application/stopped')
+  } else {
+    // Handle the case where no selection was made (e.g., reload page)
+    res.redirect('/v25/pre-application/driving-licence')
+  }
+})
+
+router.post('/v25/pre-application/distance', function (req, res) {
+  const answer = req.session.data['v25-pre-application-distance']
+
+  if (answer === 'yes') {
+    res.redirect(v25NextPreApplicationPage(req.session.data, 'distance'))
+  } else if (answer === 'no') {
+    res.redirect('/v25/pre-application/stopped')
+  } else {
+    // Handle the case where no selection was made (e.g., reload page)
+    res.redirect('/v25/pre-application/distance')
+  }
+})

--- a/app/views/sub-index-in-development.html
+++ b/app/views/sub-index-in-development.html
@@ -62,8 +62,8 @@ NHS Volunteering
 
 <div class="nhsuk-inset-text">
   <span class="nhsuk-u-visually-hidden">Information: </span>
-  <p><a href="/v25/volunteering/index">V25: <strong>Recent prototype:</strong> Filters and tags redesign &
-      results count [K5] & [K3]</a></p>
+  <p><a href="/v25/volunteering/index">V25: <strong>Recent prototype:</strong> Pre-application questions [K4], filters
+      and tags redesign & results count [K5] & [K3]</a></p>
 </div>
 
 <p><strong>Q2</strong></p>

--- a/app/views/v25/application/start.html
+++ b/app/views/v25/application/start.html
@@ -24,7 +24,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link nhsuk-u-margin-top-4">
 
-      <a class="nhsuk-back-link__link" href="../volunteering/role-profile-1">
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path
@@ -60,7 +60,7 @@ NHS Volunteering
     <h2 class="nhsuk-heading-s">If you need help with the application</h2>
 
 
-    <p><a href="../volunteering/role-profile-1">Go back to the opportunity page</a> and contact the organisation to
+    <p><a href="/v25/volunteering/role-profile-2">Go back to the opportunity page</a> and contact the organisation to
       discuss what support is available. They might offer paper forms or help you complete the online form.</p>
 
 

--- a/app/views/v25/pre-application/age.html
+++ b/app/views/v25/pre-application/age.html
@@ -1,0 +1,82 @@
+{% extends 'v25/v25_layout.html' %}
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back</a>
+    </div>
+
+    <form action="/v25/pre-application/age" method="post">
+
+      <div class="nhsuk-form-group">
+        <fieldset class="nhsuk-fieldset">
+          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+            <h1 class="nhsuk-fieldset__heading">
+              <span class="nhsuk-caption-l nhsuk-caption--top">Volunteer at St. James' Hospital application</span>
+              Are you {{ data['r20-pre-application-age'] or '18' }} or older?
+            </h1>
+          </legend>
+
+          <div class="nhsuk-radios nhsuk-radios--inline">
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-age-yes" name="v25-pre-application-age"
+                type="radio" value="yes">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-age-yes">
+                Yes
+              </label>
+            </div>
+
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-age-no" name="v25-pre-application-age"
+                type="radio" value="no">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-age-no">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <button class="nhsuk-button" type="submit">Continue</button>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}
+
+
+
+<!-- JavaScript hack to do nothing if search button or link href="" clicked -->
+{% block pageScripts %}
+<script>
+  $(document).ready(function () {
+    $('a[href=""], button.nhsuk-search__submit').click(function (e) {
+      e.preventDefault();
+    });
+  });
+</script>
+{% endblock %}

--- a/app/views/v25/pre-application/distance.html
+++ b/app/views/v25/pre-application/distance.html
@@ -1,0 +1,83 @@
+{% extends 'v25/v25_layout.html' %}
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back</a>
+    </div>
+
+    <form action="/v25/pre-application/distance" method="post">
+
+      <div class="nhsuk-form-group">
+        <fieldset class="nhsuk-fieldset">
+          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+            <h1 class="nhsuk-fieldset__heading">
+              <span class="nhsuk-caption-l nhsuk-caption--top">Volunteer at St. James' Hospital application</span>
+              Do you live or work within {{ data['r20-pre-application-distance-miles'] or '20' }} miles of
+              {{ data['r20-pre-application-distance-postcode'] or 'LS9 7TF' }}?
+            </h1>
+          </legend>
+
+          <div class="nhsuk-radios nhsuk-radios--inline">
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-distance-yes"
+                name="v25-pre-application-distance" type="radio" value="yes">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-distance-yes">
+                Yes
+              </label>
+            </div>
+
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-distance-no"
+                name="v25-pre-application-distance" type="radio" value="no">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-distance-no">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <button class="nhsuk-button" type="submit">Continue</button>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}
+
+
+
+<!-- JavaScript hack to do nothing if search button or link href="" clicked -->
+{% block pageScripts %}
+<script>
+  $(document).ready(function () {
+    $('a[href=""], button.nhsuk-search__submit').click(function (e) {
+      e.preventDefault();
+    });
+  });
+</script>
+{% endblock %}

--- a/app/views/v25/pre-application/driving-licence.html
+++ b/app/views/v25/pre-application/driving-licence.html
@@ -1,0 +1,82 @@
+{% extends 'v25/v25_layout.html' %}
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back</a>
+    </div>
+
+    <form action="/v25/pre-application/driving-licence" method="post">
+
+      <div class="nhsuk-form-group">
+        <fieldset class="nhsuk-fieldset">
+          <legend class="nhsuk-fieldset__legend nhsuk-fieldset__legend--l">
+            <h1 class="nhsuk-fieldset__heading">
+              <span class="nhsuk-caption-l nhsuk-caption--top">Volunteer at St. James' Hospital application</span>
+              Do you have a valid {{ data['r20-pre-application-licence-name'] or 'driving' }} licence?
+            </h1>
+          </legend>
+
+          <div class="nhsuk-radios nhsuk-radios--inline">
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-licence-yes" name="v25-pre-application-licence"
+                type="radio" value="yes">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-licence-yes">
+                Yes
+              </label>
+            </div>
+
+            <div class="nhsuk-radios__item">
+              <input class="nhsuk-radios__input" id="v25-pre-application-licence-no" name="v25-pre-application-licence"
+                type="radio" value="no">
+              <label class="nhsuk-label nhsuk-radios__label" for="v25-pre-application-licence-no">
+                No
+              </label>
+            </div>
+          </div>
+        </fieldset>
+      </div>
+
+      <button class="nhsuk-button" type="submit">Continue</button>
+
+    </form>
+
+  </div>
+</div>
+
+{% endblock %}
+
+
+
+<!-- JavaScript hack to do nothing if search button or link href="" clicked -->
+{% block pageScripts %}
+<script>
+  $(document).ready(function () {
+    $('a[href=""], button.nhsuk-search__submit').click(function (e) {
+      e.preventDefault();
+    });
+  });
+</script>
+{% endblock %}

--- a/app/views/v25/pre-application/start.html
+++ b/app/views/v25/pre-application/start.html
@@ -1,0 +1,90 @@
+{% extends 'v25/v25_layout.html' %}
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back</a>
+    </div>
+
+    {# Questions the recruiter selected in the r20 pre-application task. If the
+       recruiter journey hasn't been done in this session, all 3 show #}
+    {% set preAppSelected = data['r20-pre-application-questions'] %}
+    {% if preAppSelected is undefined %}
+    {% set preAppSelected = ['age', 'licence', 'distance'] %}
+    {% elif preAppSelected is string %}
+    {% set preAppSelected = [preAppSelected] %}
+    {% endif %}
+
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Volunteer at St. James' Hospital application</span>
+      Before you apply for this opportunity</h1>
+
+    <p>We need to check you meet the minimum requirements for this opportunity. We'll ask questions about your:</p>
+
+    <ul class="nhsuk-list nhsuk-list--bullet">
+      {% if 'age' in preAppSelected %}
+      <li>age</li>
+      {% endif %}
+      {% if 'distance' in preAppSelected %}
+      <li>location</li>
+      {% endif %}
+      {% if 'licence' in preAppSelected %}
+      <li>{{ data['r20-pre-application-licence-name'] or 'driving' }} licence</li>
+      {% endif %}
+    </ul>
+
+    <p>You must fill out the form in one session. You cannot save your progress.</p>
+
+    <p>By applying for this opportunity, you're confirming that you accept the recruiter's <a href="">privacy
+        policy</a>.</p>
+
+    {% if 'age' in preAppSelected %}
+    {% set preAppStartHref = '/v25/pre-application/age' %}
+    {% elif 'licence' in preAppSelected %}
+    {% set preAppStartHref = '/v25/pre-application/driving-licence' %}
+    {% elif 'distance' in preAppSelected %}
+    {% set preAppStartHref = '/v25/pre-application/distance' %}
+    {% else %}
+    {% set preAppStartHref = '/v25/application/start' %}
+    {% endif %}
+
+    <a class="nhsuk-button nhsuk-u-margin-top-3" href="{{ preAppStartHref }}">Start</a>
+
+  </div>
+</div>
+
+{% endblock %}
+
+
+
+<!-- JavaScript hack to do nothing if search button or link href="" clicked -->
+{% block pageScripts %}
+<script>
+  $(document).ready(function () {
+    $('a[href=""], button.nhsuk-search__submit').click(function (e) {
+      e.preventDefault();
+    });
+  });
+</script>
+{% endblock %}

--- a/app/views/v25/pre-application/stopped.html
+++ b/app/views/v25/pre-application/stopped.html
@@ -1,0 +1,58 @@
+{% extends 'v25/v25_layout.html' %}
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="javascript:history.back()">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back</a>
+    </div>
+
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Volunteer at St. James' Hospital application</span>
+      We have stopped your application</h1>
+
+    <p>This is because of your answers to the pre-application questions. You do not meet the minimum requirements of
+      the opportunity.</p>
+
+    <p>If you think you have answered any questions incorrectly, and you do meet the minimum requirements of the
+      opportunity, contact the recruiter using the details on the advert.</p>
+
+    <a class="nhsuk-button nhsuk-u-margin-top-3" href="/v25/results/results">Return to search results</a>
+
+  </div>
+</div>
+
+{% endblock %}
+
+
+
+<!-- JavaScript hack to do nothing if search button or link href="" clicked -->
+{% block pageScripts %}
+<script>
+  $(document).ready(function () {
+    $('a[href=""], button.nhsuk-search__submit').click(function (e) {
+      e.preventDefault();
+    });
+  });
+</script>
+{% endblock %}

--- a/app/views/v25/volunteering/role-profile-2.html
+++ b/app/views/v25/volunteering/role-profile-2.html
@@ -45,7 +45,7 @@ NHS Volunteering
       <p>The organisation may close this opportunity at any time based on their needs.</p>
     </div>
 
-    <a class="nhsuk-button nhsuk-u-margin-top-1" data-module="nhsuk-button" type="submit" href="/v25/application/start">
+    <a class="nhsuk-button nhsuk-u-margin-top-1" data-module="nhsuk-button" type="submit" href="/v25/pre-application/start">
       Apply for this opportunity
     </a>
 
@@ -216,7 +216,7 @@ NHS Volunteering
       </div>
     </details>
 
-    <a class="nhsuk-button nhsuk-u-margin-top-1" data-module="nhsuk-button" type="submit" href="/v25/application/start">
+    <a class="nhsuk-button nhsuk-u-margin-top-1" data-module="nhsuk-button" type="submit" href="/v25/pre-application/start">
       Apply for this opportunity
     </a>
 


### PR DESCRIPTION
Adds the K4 pre-application (screener) questions to the V25 volunteer journey, entered from the Trolley Volunteer opportunity (role-profile-2).

- New pages under app/views/v25/pre-application: before-you-apply start page, age, driving licence and distance questions, and a stopped page
- Questions, values and start page bullets are driven by the recruiter's R20 pre-application setup in the same session, with fallbacks when that journey has not been done
- Any No answer stops the application; all Yes answers continue to the existing application start page
- Go back links behave like the browser back button across the flow
- Sub-index V25 entry updated with the K4 tag