### PR TITLE
Remove Remote, from home from R20 opportunity setting filters

### DIFF
--- a/app/views/r20/questions/choose-search-filters.html
+++ b/app/views/r20/questions/choose-search-filters.html
@@ -74,14 +74,6 @@ Choose search filters for your opportunity - NHS Volunteering
                   </label>
                 </div>
 
-                <div class="nhsuk-checkboxes__item">
-                  <input class="nhsuk-checkboxes__input" id="r20-filter-setting-4" name="r20-filter-setting"
-                    type="checkbox" value="Remote, from home">
-                  <label class="nhsuk-label nhsuk-checkboxes__label" for="r20-filter-setting-4">
-                    Remote, from home
-                  </label>
-                </div>
-
                 <div class="nhsuk-checkboxes__divider">or</div>
 
                 <div class="nhsuk-checkboxes__item">


### PR DESCRIPTION
## Summary
- Remove the redundant "Remote, from home" checkbox from the "Where is the setting of your opportunity?" filter group on r20/questions/choose-search-filters
- r20/questions/location already captures whether an opportunity is remote, via its "The volunteer can do this remotely from their home" option, so this avoids two places that could give contradictory answers

## Test plan
- [ ] Visit /r20/questions/choose-search-filters and confirm "Remote, from home" no longer appears in the setting checkbox list
- [ ] Confirm the other options (Hospital/hospice/care facility, In local community, Office, None of these) are unaffected and the page still submits correctly