### PR TITLE
Move email to step 1 of the V25 application and renumber the following steps

### DIFF
--- a/app/views/v25/application/address.html
+++ b/app/views/v25/application/address.html
@@ -34,7 +34,7 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>
       Find your address</h1>
 
     <form action="choose-address" method="post">

--- a/app/views/v25/application/age.html
+++ b/app/views/v25/application/age.html
@@ -34,7 +34,7 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 2 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
       What is your age?</h1>
 
     <div class="nhsuk-hint nhsuk-u-margin-bottom-2">

--- a/app/views/v25/application/choose-address.html
+++ b/app/views/v25/application/choose-address.html
@@ -33,11 +33,11 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>
       Select your address</h1>
     <p>4 addresses found for '{{ data['v8-volunteer-house'] }}' and '{{ data['v8-volunteer-postcode'] }}'</p>
 
-    <form action="email" method="post">
+    <form action="phone" method="post">
 
 
       <div class="nhsuk-form-group">

--- a/app/views/v25/application/email.html
+++ b/app/views/v25/application/email.html
@@ -24,7 +24,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link nhsuk-u-margin-top-4">
 
-      <a class="nhsuk-back-link__link" href="address">
+      <a class="nhsuk-back-link__link" href="start">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path
@@ -34,7 +34,7 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>What is your email address? </h1>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 1 of 8</span>What is your email address? </h1>
     <p class="nhsuk-hint">We will only use these details to contact you about this opportunity.</p>
 
     <details class="nhsuk-details">
@@ -49,7 +49,7 @@ NHS Volunteering
       </div>
     </details>
 
-    <form action="phone" method="post">
+    <form action="name" method="post">
       <div class="nhsuk-form-group">
         <label class="nhsuk-label" for="input-width-50">
           Email address

--- a/app/views/v25/application/manual-address.html
+++ b/app/views/v25/application/manual-address.html
@@ -33,10 +33,10 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>
       What is your address?</h1>
 
-    <form action="email" method="post">
+    <form action="phone" method="post">
       <div class="nhsuk-form-group">
         <label class="nhsuk-label" for="v8-volunteer-address-line-1">
           Address line 1

--- a/app/views/v25/application/name.html
+++ b/app/views/v25/application/name.html
@@ -24,7 +24,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link nhsuk-u-margin-top-4">
 
-      <a class="nhsuk-back-link__link" href="start">
+      <a class="nhsuk-back-link__link" href="email">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path
@@ -34,7 +34,7 @@ NHS Volunteering
         Go back</a>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 1 of 8 </span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 2 of 8 </span>
       What is your name?</h1>
 
     <form action="age" method="post">

--- a/app/views/v25/application/phone.html
+++ b/app/views/v25/application/phone.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link nhsuk-u-margin-top-4">
 
-      <a class="nhsuk-back-link__link" href="email">
+      <a class="nhsuk-back-link__link" href="choose-address">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path

--- a/app/views/v25/application/start.html
+++ b/app/views/v25/application/start.html
@@ -65,7 +65,7 @@ NHS Volunteering
 
 
 
-    <a class="nhsuk-button nhsuk-u-margin-top-3" href="name">Start</a>
+    <a class="nhsuk-button nhsuk-u-margin-top-3" href="email">Start</a>
 
 
 

--- a/app/views/v25/form-errors/age-not-selected.html
+++ b/app/views/v25/form-errors/age-not-selected.html
@@ -53,7 +53,7 @@ NHS Volunteering
     <form action="../application/address" method="post">
       <div class="nhsuk-form-group nhsuk-form-group--error">
 
-        <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 2 of 8</span>
+        <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
           What is your age?</h1>
 
         <div class="nhsuk-hint nhsuk-u-margin-bottom-2">

--- a/app/views/v25/form-errors/find-address-invalid-postcode.html
+++ b/app/views/v25/form-errors/find-address-invalid-postcode.html
@@ -48,7 +48,7 @@ NHS Volunteering
         </ul>
       </div>
     </div>
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>
       Find your address</h1>
 
     <form action="choose-address" method="post">

--- a/app/views/v25/form-errors/find-address-missing.html
+++ b/app/views/v25/form-errors/find-address-missing.html
@@ -50,7 +50,7 @@ NHS Volunteering
         </ul>
       </div>
     </div>
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 3 of 8</span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 4 of 8</span>
       Find your address</h1>
 
     <form action="choose-address" method="post">

--- a/app/views/v25/form-errors/name-missing.html
+++ b/app/views/v25/form-errors/name-missing.html
@@ -47,7 +47,7 @@ NHS Volunteering
       </div>
     </div>
 
-    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 1 of 8 </span>
+    <h1><span class="nhsuk-caption-l nhsuk-caption--top">Step 2 of 8 </span>
       What is your name?</h1>
 
 

--- a/app/views/v25/form-errors/phone-character-limit.html
+++ b/app/views/v25/form-errors/phone-character-limit.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link">
 
-      <a class="nhsuk-back-link__link" href="../application/email">
+      <a class="nhsuk-back-link__link" href="../application/choose-address">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path

--- a/app/views/v25/form-errors/phone-character-valid.html
+++ b/app/views/v25/form-errors/phone-character-valid.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
     <div class="nhsuk-back-link">
 
-      <a class="nhsuk-back-link__link" href="../application/email">
+      <a class="nhsuk-back-link__link" href="../application/choose-address">
         <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
           aria-hidden="true" height="24" width="24">
           <path


### PR DESCRIPTION
Reorders the V25 volunteer application flow so the email question comes first, matching the updated design.

- Flow is now start, email (step 1 of 8), name (2), age (3), find address (4), select or manual address (4), phone (5) onwards
- Start button, form actions and back links rewired to the new order, including the manual address branch
- Step captions renumbered on the application pages and the matching form error pages
- Steps 5 to 8 (phone, availability, interview support, motivations) unchanged