### PR TITLE
Increase R20 summary and availability character limits and add italic formatting to availability

### DIFF
--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -47,6 +47,14 @@
   autogrow: true
 });</script>
 
+<!-- class name must keep the text-editor-2 prefix so character-count.js counts it as rich text -->
+<script>$('.text-editor-2-italic').trumbowyg({
+  btns: [
+  ['em']
+  ],
+  autogrow: true
+});</script>
+
 <script src="/js/character-count.js"></script>
 <!-- ****************** END TEXT EDITOR ***************** -->
 

--- a/app/views/r20/edit-journey/availability-edit.html
+++ b/app/views/r20/edit-journey/availability-edit.html
@@ -67,10 +67,10 @@
 
             <label for="example" class="nhsuk-label">Enter the availability</label>
             
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/errors/availability-empty.html
+++ b/app/views/r20/errors/availability-empty.html
@@ -84,10 +84,10 @@
               <span class="nhsuk-u-visually-hidden">Error:</span> Enter the availability details
             </span>
             
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/errors/availability-over-300-characters.html
+++ b/app/views/r20/errors/availability-over-300-characters.html
@@ -25,7 +25,7 @@
         <div class="nhsuk-error-summary__body">
           <ul class="nhsuk-list nhsuk-error-summary__list" role="list">
             <li>
-              <a href="#name">Availability details must be 300 characters or less</a>
+              <a href="#name">Availability details must be 400 characters or less</a>
             </li>
           </ul>
         </div>
@@ -81,13 +81,13 @@
             <label for="example" class="nhsuk-label">Enter availability details</label>
 
             <span class="nhsuk-error-message" id="name-error">
-              <span class="nhsuk-u-visually-hidden">Error:</span> Availability details must be 300 characters or less
+              <span class="nhsuk-u-visually-hidden">Error:</span> Availability details must be 400 characters or less
             </span>
             
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/errors/summary-empty.html
+++ b/app/views/r20/errors/summary-empty.html
@@ -74,10 +74,10 @@
             <span class="nhsuk-error-message" id="name-error">
               <span class="nhsuk-u-visually-hidden">Error:</span> Enter a summary
             </span>
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="600">
               <div class="nhsuk-form-group nhsuk-form-group--error">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="8" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400 nhsuk-input--error"></textarea>
+                <textarea rows="8" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-600 nhsuk-input--error"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/errors/summary-over-character-count.html
+++ b/app/views/r20/errors/summary-over-character-count.html
@@ -24,7 +24,7 @@
         <div class="nhsuk-error-summary__body">
           <ul class="nhsuk-list nhsuk-error-summary__list" role="list">
             <li>
-              <a href="#name">Summary must be 400 characters or less</a>
+              <a href="#name">Summary must be 600 characters or less</a>
             </li>
           </ul>
         </div>
@@ -72,12 +72,12 @@
               Enter a summary
             </label>
             <span class="nhsuk-error-message" id="name-error">
-              <span class="nhsuk-u-visually-hidden">Error:</span> Summary must be 400 characters or less
+              <span class="nhsuk-u-visually-hidden">Error:</span> Summary must be 600 characters or less
             </span>
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="600">
               <div class="nhsuk-form-group nhsuk-form-group--error">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="8" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400 nhsuk-input--error"></textarea>
+                <textarea rows="8" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-600 nhsuk-input--error"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/formatting-error-fix/availability.html
+++ b/app/views/r20/formatting-error-fix/availability.html
@@ -67,10 +67,10 @@
 
             <label for="example" class="nhsuk-label">Enter availability details</label>
             
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="12" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+                <textarea rows="12" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/formatting-error-fix/summary.html
+++ b/app/views/r20/formatting-error-fix/summary.html
@@ -58,10 +58,10 @@
             <label class="nhsuk-label" for="r9-preview">
               Enter a summary
             </label>
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="600">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="15" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
+                <textarea rows="15" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-600"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/manage-listing/questions/availability.html
+++ b/app/views/r20/manage-listing/questions/availability.html
@@ -67,10 +67,10 @@
 
             <label for="example" class="nhsuk-label">Enter the availability</label>
             
-            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+            <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
               <div class="nhsuk-form-group ">
                 <!-- to enable rich text, add class of text-editor-2 to textarea element -->
-                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+                <textarea rows="4" class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
                 <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining" >
                     You have <span class="nhsuk-character-count-remaining"></span> characters remaining
                 </p>

--- a/app/views/r20/questions/availability.html
+++ b/app/views/r20/questions/availability.html
@@ -70,11 +70,11 @@ What availability are you looking for? - NHS Volunteering
 
         <label for="example" class="nhsuk-label">Enter availability details</label>
 
-        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="300">
+        <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
           <div class="nhsuk-form-group ">
             <!-- to enable rich text, add class of text-editor-2 to textarea element -->
             <textarea rows="4"
-              class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-300"></textarea>
+              class="text-editor-2-italic nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
             <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
               You have <span class="nhsuk-character-count-remaining"></span> characters remaining
             </p>

--- a/app/views/r20/questions/summary.html
+++ b/app/views/r20/questions/summary.html
@@ -76,7 +76,7 @@ Add a summary - NHS Volunteering
           <label class="nhsuk-label" for="r9-summary">
             Enter a summary
           </label>
-          <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="400">
+          <div class="govuk-character-count" data-module="govuk-character-count" data-maxlength="600">
             <div class="nhsuk-form-group ">
               <!-- to enable rich text, add class of text-editor-2 to textarea element -->
               <textarea rows="8"


### PR DESCRIPTION
Updates the R20 create listing flow and its variants.

- Summary character limit increased from 400 to 600 (create flow question page, empty and over-limit error pages, formatting error fix page), error copy updated to match
- Availability character limit increased from 300 to 400 (create flow, manage listing, edit journey, formatting error fix, empty and over-limit error pages), error copy updated to match
- Availability question page now uses a rich text editor with an italic-only toolbar, via a new text-editor-2-italic class so the existing full toolbar pages are unaffected