### PR TITLE
Add italics to the rich text editor on the five R20 opportunity listing questions

### DIFF
--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -48,9 +48,10 @@
 });</script>
 
 <!-- class name must keep the text-editor-2 prefix so character-count.js counts it as rich text -->
-<script>$('.text-editor-2-italic').trumbowyg({
+<script>$('.text-editor-2-listing').trumbowyg({
   btns: [
-  ['em']
+  ['strong', 'em'],
+  ['unorderedList']
   ],
   autogrow: true
 });</script>

--- a/app/views/r20/questions/availability.html
+++ b/app/views/r20/questions/availability.html
@@ -74,7 +74,7 @@ What availability are you looking for? - NHS Volunteering
           <div class="nhsuk-form-group ">
             <!-- to enable rich text, add class of text-editor-2 to textarea element -->
             <textarea rows="4"
-              class="text-editor-2-italic nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
+              class="text-editor-2-listing nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-400"></textarea>
             <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
               You have <span class="nhsuk-character-count-remaining"></span> characters remaining
             </p>

--- a/app/views/r20/questions/looking-for.html
+++ b/app/views/r20/questions/looking-for.html
@@ -79,7 +79,7 @@ What type of person are you looking for? - NHS Volunteering
             <div class="nhsuk-form-group ">
               <!-- to enable rich text, add class of text-editor-2 to textarea element -->
               <textarea rows="8"
-                class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
+                class="text-editor-2-listing nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
               <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
                 You have <span class="nhsuk-character-count-remaining"></span> characters remaining
               </p>

--- a/app/views/r20/questions/opportunity-description.html
+++ b/app/views/r20/questions/opportunity-description.html
@@ -61,7 +61,7 @@ Add a description of the opportunity - NHS Volunteering
             <div class="nhsuk-form-group ">
               <!-- to enable rich text, add class of text-editor-2 to textarea element -->
               <textarea rows="8"
-                class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
+                class="text-editor-2-listing nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
               <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
                 You have <span class="nhsuk-character-count-remaining"></span> characters remaining
               </p>

--- a/app/views/r20/questions/overview-process.html
+++ b/app/views/r20/questions/overview-process.html
@@ -116,7 +116,7 @@ Add an overview of the application process - NHS Volunteering
             <div class="nhsuk-form-group ">
               <!-- to enable rich text, add class of text-editor-2 to textarea element -->
               <textarea rows="8"
-                class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
+                class="text-editor-2-listing nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-1000"></textarea>
               <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
                 You have <span class="nhsuk-character-count-remaining"></span> characters remaining
               </p>

--- a/app/views/r20/questions/summary.html
+++ b/app/views/r20/questions/summary.html
@@ -80,7 +80,7 @@ Add a summary - NHS Volunteering
             <div class="nhsuk-form-group ">
               <!-- to enable rich text, add class of text-editor-2 to textarea element -->
               <textarea rows="8"
-                class="nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-600"></textarea>
+                class="text-editor-2-listing nhsuk-textarea nhsuk-textarea-character-count nhsuk-textarea-character-count-max-600"></textarea>
               <p class="nhsuk-hint nhsuk-hint-character-count nhsuk-hint-character-count-remaining">
                 You have <span class="nhsuk-character-count-remaining"></span> characters remaining
               </p>


### PR DESCRIPTION
Gives the five create listing question screens (summary, opportunity description, what type of person, overview of the application process, availability) a shared rich text editor with bold, italic and bullet list buttons. This mirrors the editor already live on these sections and adds italics as requested.

- New text-editor-2-listing editor configuration in the shared scripts include
- Applied to the five question page textareas; character counting continues to work against the text content
- Replaces the earlier italic-only editor on the availability page
- The full-toolbar editors on trust-about and the rich text test page are unchanged