### PR TITLE
Fix missing back links across R20 screens and remove reference number from pre-application questions

### DIFF
--- a/app/views/r20/edit-journey/broader-locations/check-location-area-name.html
+++ b/app/views/r20/edit-journey/broader-locations/check-location-area-name.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/check-location-final.html
+++ b/app/views/r20/edit-journey/broader-locations/check-location-final.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/check-location-radius.html
+++ b/app/views/r20/edit-journey/broader-locations/check-location-radius.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-area-name",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/choose-address-larger-area.html
+++ b/app/views/r20/edit-journey/broader-locations/choose-address-larger-area.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/location-larger-area.html
+++ b/app/views/r20/edit-journey/broader-locations/location-larger-area.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/location.html
+++ b/app/views/r20/edit-journey/broader-locations/location.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "support-volunteers",
     "text": "Go back",

--- a/app/views/r20/edit-journey/broader-locations/manual-address-larger-area.html
+++ b/app/views/r20/edit-journey/broader-locations/manual-address-larger-area.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/edit-journey/check-listing-edit.html
+++ b/app/views/r20/edit-journey/check-listing-edit.html
@@ -6,14 +6,6 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
-  {{ backLink({
-    "href": "../../task-list-completed",
-    "text": "Go back",
-    "classes": "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
-  }) }}
-{% endblock %}
-
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-full">

--- a/app/views/r20/errors/address-empty.html
+++ b/app/views/r20/errors/address-empty.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "remote",
     "text": "Go back",

--- a/app/views/r20/errors/address-invalid-postcode.html
+++ b/app/views/r20/errors/address-invalid-postcode.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "remote",
     "text": "Go back",

--- a/app/views/r20/errors/address-not-found.html
+++ b/app/views/r20/errors/address-not-found.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../questions/address",
     "text": "Go back",

--- a/app/views/r20/errors/alt-closing-date-answer-future.html
+++ b/app/views/r20/errors/alt-closing-date-answer-future.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/errors/alt-closing-date-answer-input-invalid.html
+++ b/app/views/r20/errors/alt-closing-date-answer-input-invalid.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/errors/alt-closing-date-answer-input-missing.html
+++ b/app/views/r20/errors/alt-closing-date-answer-input-missing.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/errors/alt-closing-date-answer-input-over-365-days.html
+++ b/app/views/r20/errors/alt-closing-date-answer-input-over-365-days.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/errors/alt-closing-date-select-one.html
+++ b/app/views/r20/errors/alt-closing-date-select-one.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "application-limits",
     "text": "Go back",

--- a/app/views/r20/errors/another-location-empty.html
+++ b/app/views/r20/errors/another-location-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/errors/application-limits-empty.html
+++ b/app/views/r20/errors/application-limits-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "review-questions",
     "text": "Go back",

--- a/app/views/r20/errors/application-limits-more-than-30000.html
+++ b/app/views/r20/errors/application-limits-more-than-30000.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "review-questions",
     "text": "Go back",

--- a/app/views/r20/errors/application-limits-no-limit.html
+++ b/app/views/r20/errors/application-limits-no-limit.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "review-questions",
     "text": "Go back",

--- a/app/views/r20/errors/application-limits-not-a-number.html
+++ b/app/views/r20/errors/application-limits-not-a-number.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "review-questions",
     "text": "Go back",

--- a/app/views/r20/errors/application-limits-not-a-whole-number.html
+++ b/app/views/r20/errors/application-limits-not-a-whole-number.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "review-questions",
     "text": "Go back",

--- a/app/views/r20/errors/availability-empty.html
+++ b/app/views/r20/errors/availability-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/errors/availability-over-300-characters.html
+++ b/app/views/r20/errors/availability-over-300-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/errors/check-location-area-name-less-than-3-characters.html
+++ b/app/views/r20/errors/check-location-area-name-less-than-3-characters.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/errors/check-location-area-name-more-than-255-characters.html
+++ b/app/views/r20/errors/check-location-area-name-more-than-255-characters.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/errors/check-location-area-name-no-input.html
+++ b/app/views/r20/errors/check-location-area-name-no-input.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/errors/check-location-not-selected.html
+++ b/app/views/r20/errors/check-location-not-selected.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/errors/check-location-radius-not-selected.html
+++ b/app/views/r20/errors/check-location-radius-not-selected.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-area-name",
     "text": "Go back",

--- a/app/views/r20/errors/choose-address-empty.html
+++ b/app/views/r20/errors/choose-address-empty.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/errors/choose-address-larger-area-no-input.html
+++ b/app/views/r20/errors/choose-address-larger-area-no-input.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/errors/choose-search-filters-edit-no-selection.html
+++ b/app/views/r20/errors/choose-search-filters-edit-no-selection.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/choose-search-filters-no-selection.html
+++ b/app/views/r20/errors/choose-search-filters-no-selection.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/contact-details-change-character-limits.html
+++ b/app/views/r20/errors/contact-details-change-character-limits.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "contact-details",
     "text": "Go back",

--- a/app/views/r20/errors/contact-details-change-email-format.html
+++ b/app/views/r20/errors/contact-details-change-email-format.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "contact-details",
     "text": "Go back",

--- a/app/views/r20/errors/contact-details-change-empty.html
+++ b/app/views/r20/errors/contact-details-change-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "contact-details",
     "text": "Go back",

--- a/app/views/r20/errors/contact-details-empty.html
+++ b/app/views/r20/errors/contact-details-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "availability",
     "text": "Go back",

--- a/app/views/r20/errors/limit-exceeded-trust-about.html
+++ b/app/views/r20/errors/limit-exceeded-trust-about.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "trust-result",
     "text": "Go back",

--- a/app/views/r20/errors/location-larger-area-more-than-125-characters.html
+++ b/app/views/r20/errors/location-larger-area-more-than-125-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/errors/location-larger-area-no-input.html
+++ b/app/views/r20/errors/location-larger-area-no-input.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/errors/location-larger-area-non-english-postcode.html
+++ b/app/views/r20/errors/location-larger-area-non-english-postcode.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/errors/location-no-selection.html
+++ b/app/views/r20/errors/location-no-selection.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/looking-for-empty.html
+++ b/app/views/r20/errors/looking-for-empty.html
@@ -6,7 +6,7 @@
 Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "opportunity-description",
 "text": "Go back",

--- a/app/views/r20/errors/looking-for-more-than-1000-characters.html
+++ b/app/views/r20/errors/looking-for-more-than-1000-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "opportunity-description",
     "text": "Go back",

--- a/app/views/r20/errors/manual-address-empty.html
+++ b/app/views/r20/errors/manual-address-empty.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/errors/manual-address-invalid-postcode.html
+++ b/app/views/r20/errors/manual-address-invalid-postcode.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/errors/manual-address-larger-area-no-input.html
+++ b/app/views/r20/errors/manual-address-larger-area-no-input.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/errors/manual-address-larger-area-non-english-postcode.html
+++ b/app/views/r20/errors/manual-address-larger-area-non-english-postcode.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/errors/name-field-empty.html
+++ b/app/views/r20/errors/name-field-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/no-trust-about.html
+++ b/app/views/r20/errors/no-trust-about.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "trust-result",
     "text": "Go back",

--- a/app/views/r20/errors/opportunity-description-empty.html
+++ b/app/views/r20/errors/opportunity-description-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "summary",
     "text": "Go back",

--- a/app/views/r20/errors/opportunity-description-over-1000-characters.html
+++ b/app/views/r20/errors/opportunity-description-over-1000-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "summary",
     "text": "Go back",

--- a/app/views/r20/errors/opportunity-name-character-limit-exceeded.html
+++ b/app/views/r20/errors/opportunity-name-character-limit-exceeded.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "start-page",
     "text": "Go back",

--- a/app/views/r20/errors/opportunity-name-empty.html
+++ b/app/views/r20/errors/opportunity-name-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "start-page",
     "text": "Go back",

--- a/app/views/r20/errors/overview-process-empty.html
+++ b/app/views/r20/errors/overview-process-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "looking-for",
     "text": "Go back",

--- a/app/views/r20/errors/overview-process-more-than-1000-characters.html
+++ b/app/views/r20/errors/overview-process-more-than-1000-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "looking-for",
     "text": "Go back",

--- a/app/views/r20/errors/preview-empty.html
+++ b/app/views/r20/errors/preview-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/preview-over-character-count.html
+++ b/app/views/r20/errors/preview-over-character-count.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/recieve-applications-empty-link.html
+++ b/app/views/r20/errors/recieve-applications-empty-link.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/recieve-applications-empty.html
+++ b/app/views/r20/errors/recieve-applications-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/recieve-applications-incorrect-link.html
+++ b/app/views/r20/errors/recieve-applications-incorrect-link.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/recieve-applications-over-255-characters.html
+++ b/app/views/r20/errors/recieve-applications-over-255-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/remote-empty.html
+++ b/app/views/r20/errors/remote-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "support-volunteers",
     "text": "Go back",

--- a/app/views/r20/errors/summary-empty.html
+++ b/app/views/r20/errors/summary-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list-completed",
     "text": "Go back",

--- a/app/views/r20/errors/summary-over-character-count.html
+++ b/app/views/r20/errors/summary-over-character-count.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list-completed",
     "text": "Go back",

--- a/app/views/r20/errors/support-volunteer-empty.html
+++ b/app/views/r20/errors/support-volunteer-empty.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "overview-process",
     "text": "Go back",

--- a/app/views/r20/errors/support-volunteer-over-300-characters.html
+++ b/app/views/r20/errors/support-volunteer-over-300-characters.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "overview-process",
     "text": "Go back",

--- a/app/views/r20/errors/tags-edit-no-selection.html
+++ b/app/views/r20/errors/tags-edit-no-selection.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/tags-edit-selection-more-than-3.html
+++ b/app/views/r20/errors/tags-edit-selection-more-than-3.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/tags-no-selection.html
+++ b/app/views/r20/errors/tags-no-selection.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/errors/tags-selection-more-than-3.html
+++ b/app/views/r20/errors/tags-selection-more-than-3.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/formatting-error-fix/availability.html
+++ b/app/views/r20/formatting-error-fix/availability.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/formatting-error-fix/looking-for.html
+++ b/app/views/r20/formatting-error-fix/looking-for.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "opportunity-description",
     "text": "Go back",

--- a/app/views/r20/formatting-error-fix/opportunity-description.html
+++ b/app/views/r20/formatting-error-fix/opportunity-description.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "summary",
     "text": "Go back",

--- a/app/views/r20/formatting-error-fix/overview-process.html
+++ b/app/views/r20/formatting-error-fix/overview-process.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "looking-for",
     "text": "Go back",

--- a/app/views/r20/formatting-error-fix/summary.html
+++ b/app/views/r20/formatting-error-fix/summary.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list-completed",
     "text": "Go back",

--- a/app/views/r20/manage-listing/check-listing-edit.html
+++ b/app/views/r20/manage-listing/check-listing-edit.html
@@ -6,7 +6,7 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../../task-list-completed",
     "text": "Go back",

--- a/app/views/r20/manage-listing/edit-application-limits.html
+++ b/app/views/r20/manage-listing/edit-application-limits.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "manage-live",
     "text": "Go back",

--- a/app/views/r20/manage-listing/edit-closing-date.html
+++ b/app/views/r20/manage-listing/edit-closing-date.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/manage-listing/manage-application.html
+++ b/app/views/r20/manage-listing/manage-application.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "manage-live",
     "text": "Go back",

--- a/app/views/r20/manage-listing/preview.html
+++ b/app/views/r20/manage-listing/preview.html
@@ -6,7 +6,7 @@
   Opportunity preview
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "manage-live",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/address.html
+++ b/app/views/r20/manage-listing/questions/address.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "remote",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/alt-closing-date-answer.html
+++ b/app/views/r20/manage-listing/questions/alt-closing-date-answer.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/alt-closing-date.html
+++ b/app/views/r20/manage-listing/questions/alt-closing-date.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "application-limits",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/another-location.html
+++ b/app/views/r20/manage-listing/questions/another-location.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/application-limits.html
+++ b/app/views/r20/manage-listing/questions/application-limits.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recieve-applications",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/archived/closing-date.html
+++ b/app/views/r20/manage-listing/questions/archived/closing-date.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recieve-applications",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/archived/create-an-opportunity.html
+++ b/app/views/r20/manage-listing/questions/archived/create-an-opportunity.html
@@ -4,7 +4,7 @@
     Create an opportunity advert
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/archived/listing-visibility.html
+++ b/app/views/r20/manage-listing/questions/archived/listing-visibility.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recieve-applications",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/archived/reference-number.html
+++ b/app/views/r20/manage-listing/questions/archived/reference-number.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "new-name",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/availability.html
+++ b/app/views/r20/manage-listing/questions/availability.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/check-listing.html
+++ b/app/views/r20/manage-listing/questions/check-listing.html
@@ -6,7 +6,7 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../../task-list-completed",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/check-location.html
+++ b/app/views/r20/manage-listing/questions/check-location.html
@@ -6,7 +6,7 @@
   Check answers
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/choose-address.html
+++ b/app/views/r20/manage-listing/questions/choose-address.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/contact-details-change.html
+++ b/app/views/r20/manage-listing/questions/contact-details-change.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "contact-details",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/contact-details.html
+++ b/app/views/r20/manage-listing/questions/contact-details.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "availability",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/looking-for.html
+++ b/app/views/r20/manage-listing/questions/looking-for.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "summary",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/manual-address.html
+++ b/app/views/r20/manage-listing/questions/manual-address.html
@@ -12,7 +12,7 @@
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/new-name.html
+++ b/app/views/r20/manage-listing/questions/new-name.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/opportunity-creation-check-listing.html
+++ b/app/views/r20/manage-listing/questions/opportunity-creation-check-listing.html
@@ -6,7 +6,7 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/overview-process.html
+++ b/app/views/r20/manage-listing/questions/overview-process.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "looking-for",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/preview.html
+++ b/app/views/r20/manage-listing/questions/preview.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/recieve-applications.html
+++ b/app/views/r20/manage-listing/questions/recieve-applications.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/remote.html
+++ b/app/views/r20/manage-listing/questions/remote.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "support-volunteers",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/review-questions.html
+++ b/app/views/r20/manage-listing/questions/review-questions.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recieve-applications",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/rich-text-test.html
+++ b/app/views/r20/manage-listing/questions/rich-text-test.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "create-an-opportunity",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/summary.html
+++ b/app/views/r20/manage-listing/questions/summary.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "preview",
     "text": "Go back",

--- a/app/views/r20/manage-listing/questions/support-volunteers.html
+++ b/app/views/r20/manage-listing/questions/support-volunteers.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "overview-process",
     "text": "Go back",

--- a/app/views/r20/manage-listing/reuse-listing-interstitial.html
+++ b/app/views/r20/manage-listing/reuse-listing-interstitial.html
@@ -4,7 +4,7 @@
   Start page template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "manage-live",
     "text": "Go back",

--- a/app/views/r20/opportunity-name.html
+++ b/app/views/r20/opportunity-name.html
@@ -6,7 +6,7 @@
 Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "r13/start-page",
 "text": "Go back",

--- a/app/views/r20/preview.html
+++ b/app/views/r20/preview.html
@@ -6,7 +6,7 @@
 Opportunity preview
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "questions/check-listing",
 "text": "Go back",

--- a/app/views/r20/questions/address.html
+++ b/app/views/r20/questions/address.html
@@ -12,7 +12,7 @@ Add a location - NHS Volunteering
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/questions/alt-closing-date-answer.html
+++ b/app/views/r20/questions/alt-closing-date-answer.html
@@ -6,7 +6,7 @@
 Enter a closing date - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "alt-closing-date",
     "text": "Go back",

--- a/app/views/r20/questions/alt-closing-date.html
+++ b/app/views/r20/questions/alt-closing-date.html
@@ -6,7 +6,7 @@
 Do you want to set a closing date? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "receive-applications",
     "text": "Go back",

--- a/app/views/r20/questions/another-location.html
+++ b/app/views/r20/questions/another-location.html
@@ -6,7 +6,7 @@
 Do you want to add another location for this opportunity? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/questions/availability.html
+++ b/app/views/r20/questions/availability.html
@@ -6,7 +6,7 @@
 What availability are you looking for? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "location",
 "text": "Go back",

--- a/app/views/r20/questions/change-email-details.html
+++ b/app/views/r20/questions/change-email-details.html
@@ -6,7 +6,7 @@
 Change details - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "contact-details",
 "text": "Go back",

--- a/app/views/r20/questions/change-email-updates.html
+++ b/app/views/r20/questions/change-email-updates.html
@@ -6,7 +6,7 @@
 Do you want to keep the same settings for email notifications? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "receive-applications",
 "text": "Go back",

--- a/app/views/r20/questions/check-listing.html
+++ b/app/views/r20/questions/check-listing.html
@@ -6,7 +6,7 @@
 Check your answers before publishing your listing - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "../task-list",
 "text": "Go back",

--- a/app/views/r20/questions/check-location-area-name.html
+++ b/app/views/r20/questions/check-location-area-name.html
@@ -6,7 +6,7 @@
 Add an area name - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location",
     "text": "Go back",

--- a/app/views/r20/questions/check-location-final.html
+++ b/app/views/r20/questions/check-location-final.html
@@ -6,7 +6,7 @@
 Check your location - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/questions/check-location-label.html
+++ b/app/views/r20/questions/check-location-label.html
@@ -6,7 +6,7 @@
 Add opportunity tags - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/questions/check-location-max-limit.html
+++ b/app/views/r20/questions/check-location-max-limit.html
@@ -6,7 +6,7 @@
 Check locations - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/questions/check-location-radius.html
+++ b/app/views/r20/questions/check-location-radius.html
@@ -6,7 +6,7 @@
 Add a radius - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-area-name",
     "text": "Go back",

--- a/app/views/r20/questions/check-location.html
+++ b/app/views/r20/questions/check-location.html
@@ -6,7 +6,7 @@
 Check locations - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/questions/choose-accessible-filters.html
+++ b/app/views/r20/questions/choose-accessible-filters.html
@@ -6,7 +6,7 @@
 How accessible is this opportunity? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "choose-search-filters",
 "text": "Go back",

--- a/app/views/r20/questions/choose-address-larger-area.html
+++ b/app/views/r20/questions/choose-address-larger-area.html
@@ -12,7 +12,7 @@ Select an address - NHS Volunteering
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/questions/choose-address.html
+++ b/app/views/r20/questions/choose-address.html
@@ -12,7 +12,7 @@ Select an address - NHS Volunteering
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/questions/choose-search-filters.html
+++ b/app/views/r20/questions/choose-search-filters.html
@@ -6,7 +6,7 @@
 Choose search filters for your opportunity - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "../task-list",
 "text": "Go back",

--- a/app/views/r20/questions/contact-details-change.html
+++ b/app/views/r20/questions/contact-details-change.html
@@ -6,7 +6,7 @@
 Change the contact details - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "contact-details",
     "text": "Go back",

--- a/app/views/r20/questions/contact-details.html
+++ b/app/views/r20/questions/contact-details.html
@@ -6,7 +6,7 @@
 Are these the correct contact details? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "availability",
 "text": "Go back",

--- a/app/views/r20/questions/define-filtering.html
+++ b/app/views/r20/questions/define-filtering.html
@@ -6,7 +6,7 @@
 Define your opportunity - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "../task-list",
 "text": "Go back",

--- a/app/views/r20/questions/edit-opportunity-interstitial.html
+++ b/app/views/r20/questions/edit-opportunity-interstitial.html
@@ -12,7 +12,7 @@ We will be taking you back to the task list now - NHS Volunteering
 <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "#",
 "text": "Go back",

--- a/app/views/r20/questions/email-details-manual-confirm-2.html
+++ b/app/views/r20/questions/email-details-manual-confirm-2.html
@@ -6,7 +6,7 @@
 Is this the correct email address? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "availability",
 "text": "Go back",

--- a/app/views/r20/questions/email-details-manual-confirm.html
+++ b/app/views/r20/questions/email-details-manual-confirm.html
@@ -6,7 +6,7 @@
 Are these the correct details? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "availability",
 "text": "Go back",

--- a/app/views/r20/questions/email-details.html
+++ b/app/views/r20/questions/email-details.html
@@ -6,7 +6,7 @@
 Is this the correct email address? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "availability",
 "text": "Go back",

--- a/app/views/r20/questions/email-updates-answer-radio.html
+++ b/app/views/r20/questions/email-updates-answer-radio.html
@@ -6,7 +6,7 @@
 Who will receive email notifications - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "receive-applications",
 "text": "Go back",

--- a/app/views/r20/questions/email-updates-answer.html
+++ b/app/views/r20/questions/email-updates-answer.html
@@ -6,7 +6,7 @@
 Who will receive email notifications? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "alt-closing-date",
 "text": "Go back",

--- a/app/views/r20/questions/email-updates-manual-input-error.html
+++ b/app/views/r20/questions/email-updates-manual-input-error.html
@@ -6,7 +6,7 @@
 Enter new details - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "contact-details",
 "text": "Go back",

--- a/app/views/r20/questions/email-updates-manual-input.html
+++ b/app/views/r20/questions/email-updates-manual-input.html
@@ -6,7 +6,7 @@
 Enter email address - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "contact-details",
 "text": "Go back",

--- a/app/views/r20/questions/email-updates.html
+++ b/app/views/r20/questions/email-updates.html
@@ -6,7 +6,7 @@
 Do you want to set up email notifications for this opportunity? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "receive-applications",
 "text": "Go back",

--- a/app/views/r20/questions/location-larger-area.html
+++ b/app/views/r20/questions/location-larger-area.html
@@ -6,7 +6,7 @@
 Add an area centre point - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "check-location-radius",
     "text": "Go back",

--- a/app/views/r20/questions/location.html
+++ b/app/views/r20/questions/location.html
@@ -6,7 +6,7 @@
 Where is this opportunity? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "support-volunteers",
 "text": "Go back",

--- a/app/views/r20/questions/looking-for.html
+++ b/app/views/r20/questions/looking-for.html
@@ -6,7 +6,7 @@
 What type of person are you looking for? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "opportunity-description",
 "text": "Go back",

--- a/app/views/r20/questions/manual-address-larger-area.html
+++ b/app/views/r20/questions/manual-address-larger-area.html
@@ -12,7 +12,7 @@ What is the address? - NHS Volunteering
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "location-larger-area",
     "text": "Go back",

--- a/app/views/r20/questions/manual-address.html
+++ b/app/views/r20/questions/manual-address.html
@@ -12,7 +12,7 @@ What is the address? - NHS Volunteering
   <link href="/css/nhsuk.css" rel="stylesheet">
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "address",
     "text": "Go back",

--- a/app/views/r20/questions/new-name.html
+++ b/app/views/r20/questions/new-name.html
@@ -6,7 +6,7 @@
 Enter a title for the opportunity listing - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/questions/opportunity-description.html
+++ b/app/views/r20/questions/opportunity-description.html
@@ -6,7 +6,7 @@
 Add a description of the opportunity - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "summary",
 "text": "Go back",

--- a/app/views/r20/questions/overview-process.html
+++ b/app/views/r20/questions/overview-process.html
@@ -6,7 +6,7 @@
 Add an overview of the application process - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "looking-for",
 "text": "Go back",

--- a/app/views/r20/questions/pre-application-distance.html
+++ b/app/views/r20/questions/pre-application-distance.html
@@ -6,7 +6,7 @@
 Enter a maximum distance from the opportunity's postcode - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "select-pre-application-questions",
 "text": "Go back",
@@ -22,8 +22,6 @@ Enter a maximum distance from the opportunity's postcode - NHS Volunteering
       <span class="nhsuk-caption-l nhsuk-caption--top">Create an opportunity advert</span>
       Enter a maximum distance from the opportunity's postcode
     </h1>
-
-    <p class="nhsuk-body-s">Reference no: E6789-26-0001</p>
 
     <p class="nhsuk-body">Enter the maximum distance the volunteer can live or work from the opportunity's postcode, such as 20
       miles. Consider how easily the volunteer might be able to get to the location.</p>

--- a/app/views/r20/questions/pre-application-licence.html
+++ b/app/views/r20/questions/pre-application-licence.html
@@ -6,7 +6,7 @@
 Enter the name of the required licence - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "select-pre-application-questions",
 "text": "Go back",
@@ -22,8 +22,6 @@ Enter the name of the required licence - NHS Volunteering
       <span class="nhsuk-caption-l nhsuk-caption--top">Create an opportunity advert</span>
       Enter the name of the required licence
     </h1>
-
-    <p class="nhsuk-body-s">Reference no: E6789-26-0001</p>
 
     <p class="nhsuk-body">Enter the name of the licence required for the opportunity.</p>
 

--- a/app/views/r20/questions/pre-application-minimum-age.html
+++ b/app/views/r20/questions/pre-application-minimum-age.html
@@ -6,7 +6,7 @@
 Enter the minimum age required - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "select-pre-application-questions",
 "text": "Go back",
@@ -22,8 +22,6 @@ Enter the minimum age required - NHS Volunteering
       <span class="nhsuk-caption-l nhsuk-caption--top">Create an opportunity advert</span>
       Enter the minimum age required
     </h1>
-
-    <p class="nhsuk-body-s">Reference no: E6789-26-0001</p>
 
     <p class="nhsuk-body">Make sure any age restriction is necessary and complies with your organisation's volunteer
       recruitment policies and equality legislation.</p>

--- a/app/views/r20/questions/pre-application-questions.html
+++ b/app/views/r20/questions/pre-application-questions.html
@@ -6,7 +6,7 @@
 Do you want to add any pre-application questions? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "overview-process",
 "text": "Go back",
@@ -29,8 +29,6 @@ Do you want to add any pre-application questions? - NHS Volunteering
               Do you want to add any pre-application questions?
             </h1>
           </legend>
-
-          <p class="nhsuk-body-s">Reference no: E6789-26-0001</p>
 
           <p class="nhsuk-body">You can use pre-application questions to make sure all applicants meet the essential
             requirements of the opportunity.</p>

--- a/app/views/r20/questions/preview.html
+++ b/app/views/r20/questions/preview.html
@@ -6,7 +6,7 @@
 Ward support volunteer - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "manage-live",
     "text": "Go back",

--- a/app/views/r20/questions/recieve-applications.html
+++ b/app/views/r20/questions/recieve-applications.html
@@ -6,7 +6,7 @@
 Do you want to receive applications through NHS Volunteering? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "../task-list",
     "text": "Go back",

--- a/app/views/r20/questions/recruiter-email-preview.html
+++ b/app/views/r20/questions/recruiter-email-preview.html
@@ -6,7 +6,7 @@
 Application for Walk and Talk Volunteer - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "receive-applications",
 "text": "Go back",

--- a/app/views/r20/questions/review-questions.html
+++ b/app/views/r20/questions/review-questions.html
@@ -6,7 +6,7 @@
 Review the application questions - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recieve-applications",
     "text": "Go back",

--- a/app/views/r20/questions/select-pre-application-questions.html
+++ b/app/views/r20/questions/select-pre-application-questions.html
@@ -6,7 +6,7 @@
 Select the pre-application questions - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "pre-application-questions",
 "text": "Go back",
@@ -29,8 +29,6 @@ Select the pre-application questions - NHS Volunteering
               Select the pre-application questions
             </h1>
           </legend>
-
-          <p class="nhsuk-body-s">Reference no: E6789-26-0001</p>
 
           <p class="nhsuk-body">Select questions that check whether applicants meet the requirements for this volunteer
             role.</p>

--- a/app/views/r20/questions/summary.html
+++ b/app/views/r20/questions/summary.html
@@ -6,13 +6,6 @@
 Add a summary - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
-{{ backLink({
-"href": "../task-list",
-"text": "Go back",
-"classes": "nhsuk-u-margin-top-4 nhsuk-u-margin-bottom-0"
-}) }}
-{% endblock %}
 {% block content %}
 <div class="nhsuk-grid-row">
   <div class="nhsuk-grid-column-two-thirds">

--- a/app/views/r20/questions/support-volunteers.html
+++ b/app/views/r20/questions/support-volunteers.html
@@ -6,7 +6,7 @@
 Who will support the volunteer? - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "pre-application-questions",
     "text": "Go back",

--- a/app/views/r20/questions/tags.html
+++ b/app/views/r20/questions/tags.html
@@ -6,7 +6,7 @@
 Add opportunity tags - NHS Volunteering
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "../task-list",
 "text": "Go back",

--- a/app/views/r20/start-page.html
+++ b/app/views/r20/start-page.html
@@ -4,7 +4,7 @@
 Start page template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "index",
 "text": "Go back",

--- a/app/views/r20/task-list-email-completed-listing-live.html
+++ b/app/views/r20/task-list-email-completed-listing-live.html
@@ -6,7 +6,7 @@
 Task list
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "index",
 "text": "Go back to dashboard",

--- a/app/views/r20/task-list-email-completed.html
+++ b/app/views/r20/task-list-email-completed.html
@@ -6,7 +6,7 @@
 Task list
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "index",
 "text": "Go back to dashboard",

--- a/app/views/r20/task-list-location-completed.html
+++ b/app/views/r20/task-list-location-completed.html
@@ -6,7 +6,7 @@
 Task list
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "index",
 "text": "Go back to dashboard",

--- a/app/views/r20/task-list.html
+++ b/app/views/r20/task-list.html
@@ -6,7 +6,7 @@
 Task list
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
 {{ backLink({
 "href": "index",
 "text": "Go back to dashboard",

--- a/app/views/r20/trust-about-check.html
+++ b/app/views/r20/trust-about-check.html
@@ -6,7 +6,7 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "trust-about",
     "text": "Go back",

--- a/app/views/r20/trust-about.html
+++ b/app/views/r20/trust-about.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recruiter-trust-details",
     "text": "Go back",

--- a/app/views/r20/trust-url-check.html
+++ b/app/views/r20/trust-url-check.html
@@ -6,7 +6,7 @@
   Check your answers template - NHS.UK prototype kit
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "trust-url",
     "text": "Go back",

--- a/app/views/r20/trust-url.html
+++ b/app/views/r20/trust-url.html
@@ -6,7 +6,7 @@
   Question page
 {% endblock %}
 
-{% block outerContent %}
+{% block beforeContent %}
   {{ backLink({
     "href": "recruiter-trust-details",
     "text": "Go back",


### PR DESCRIPTION
Renames the dead outerContent Nunjucks block to beforeContent across the R20 views so back links render again. The prototype kit dropped the outerContent block in v5.0.0, which silently hid every back link placed in it.

Also removes the revived duplicate back link block on the summary and check-listing-edit screens, and removes the reference number line from the five pre-application question screens.