### PR TITLE
Remove doubled width container from main element in layouts

### DIFF
--- a/app/views/layout_vol_header-no-footer-links.html
+++ b/app/views/layout_vol_header-no-footer-links.html
@@ -8,7 +8,7 @@
 {% extends "page-example.html" %}
 
 {% from "back-link/macro.njk" import backLink %}
-{% set mainClasses = "nhsuk-width-container nhsuk-main-wrapper nhsuk-u-margin-bottom-7" %}
+{% set mainClasses = "nhsuk-u-margin-bottom-7" %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block head %}

--- a/app/views/layout_vol_header.html
+++ b/app/views/layout_vol_header.html
@@ -8,7 +8,7 @@
 {% extends "layout.html" %}
 
 {% from "back-link/macro.njk" import backLink %}
-{% set mainClasses = "nhsuk-width-container nhsuk-main-wrapper nhsuk-u-margin-bottom-7" %}
+{% set mainClasses = "nhsuk-u-margin-bottom-7" %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block head %}

--- a/app/views/layout_vol_header_recruiter.html
+++ b/app/views/layout_vol_header_recruiter.html
@@ -8,7 +8,7 @@
 {% extends "page-example.html" %}
 
 {% from "back-link/macro.njk" import backLink %}
-{% set mainClasses = "nhsuk-width-container nhsuk-main-wrapper nhsuk-u-margin-bottom-7" %}
+{% set mainClasses = "nhsuk-u-margin-bottom-7" %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block head %}

--- a/app/views/v25/v25_layout_vol_header.html
+++ b/app/views/v25/v25_layout_vol_header.html
@@ -8,7 +8,7 @@
 {% extends "page-example.html" %}
 
 {% from "back-link/macro.njk" import backLink %}
-{% set mainClasses = "nhsuk-width-container nhsuk-main-wrapper nhsuk-u-margin-bottom-7" %}
+{% set mainClasses = "nhsuk-u-margin-bottom-7" %}
 
 <!-- Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 {% block head %}


### PR DESCRIPTION
The prototype kit template already wraps the back link and main content in a single nhsuk-width-container. Four layouts added nhsuk-width-container to the main element as well, nesting one width container inside another. Below a 1024px viewport the inner container gains a real 32px (16px below 769px) margin, so body content was indented relative to the back link at browser zoom levels of 175% and above. Removing the doubled classes aligns the content with the back link at every viewport width. Verified at 900px and 768px viewports and smoke tested the r20 task list, r20 dashboard and v25 pages.