### PR TITLE
Restore v19 submitted-v3-equality-removed page

### DIFF
--- a/app/views/v19/application/submitted-v3-equality-removed.html
+++ b/app/views/v19/application/submitted-v3-equality-removed.html
@@ -1,0 +1,124 @@
+{% extends 'layout.html' %}
+
+<!-- some custom css for the home page only -->
+
+
+{% block pageTitle %}
+NHS Volunteering
+{% endblock %}
+
+{% block headCSS %}
+<link href="/css/main.css" rel="stylesheet">
+<link href="/css/nhsuk.css" rel="stylesheet">
+{% endblock %}
+
+<!-- NHS.UK header -->
+
+
+
+<!-- Homepage content -->
+{% block content %}
+
+<div class="nhsuk-grid-row">
+  <div class="nhsuk-grid-column-two-thirds">
+
+    <div class="nhsuk-back-link nhsuk-u-margin-top-4">
+
+      <a class="nhsuk-back-link__link" href="/v19/results/results">
+        <svg class="nhsuk-icon nhsuk-icon__chevron-left" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+          aria-hidden="true" height="24" width="24">
+          <path
+            d="M8.5 12c0-.3.1-.5.3-.7l5-5c.4-.4 1-.4 1.4 0s.4 1 0 1.4L10.9 12l4.3 4.3c.4.4.4 1 0 1.4s-1 .4-1.4 0l-5-5c-.2-.2-.3-.4-.3-.7z">
+          </path>
+        </svg>
+        Go back to results</a>
+    </div>
+  </div>
+</div>
+
+<div class="nhsuk-width-container">
+  <main class="nhsuk-main-wrapper nhsuk-main-wrapper--l" id="main-content" role="main">
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+        <div class="nhsuk-panel nhsuk-panel--confirmation">
+          <h1 class="nhsuk-panel__title">
+            Application complete
+          </h1>
+          <div class="nhsuk-panel__body">
+            Volunteer at St James Hospital
+            <br>
+            Your reference number:<strong> 1384250</strong name="format-detection" content="telephone=no">
+          </div>
+        </div>
+
+        <p class="nhsuk-body">We have emailed you at volunteer@email.com to confirm your application for this
+          volunteering opportunity.</p>
+
+        <h1 class="nhsuk-heading-l">What happens next</h1>
+
+        <p class="nhsuk-body">
+          You'll hear back from the organisation after they review your application. This might take a few weeks.</p>
+        <div>
+        </div>
+        </p>
+        <h4>If your application is successful:</h4>
+
+        <p>Someone from the organisation will be in touch to invite you for an informal conversation. This will be to
+          learn more
+          about yourself and the support you can provide.</p>
+        <p>This could be in person, over the phone or via video
+          conference.</p>
+
+        <div>
+          <hr>
+        </div>
+        <h4>Before you start you may need to provide:</h4>
+        <ul class="nhsuk-list nhsuk-list--bullet">
+          <li>some documents for identity checks (ID, bills or bank statements)
+          </li>
+          <li>your emergency contact details</li>
+          <li>your driving licence (where relevant)
+          </li>
+          <li>your right to work in the UK</li>
+          <li>two referees</li>
+        </ul>
+
+        <p>The NHS uses DBS checks to protect vulnerable people. Depending on the type of opportunity, you may need to
+          go through a check. This might take a few weeks to come back.</p>
+        <div>
+          <hr>
+        </div>
+        <h4>Once you are ready to start:</h4>
+        <p>You will have a welcome induction. It will be an opportunity for you to meet the staff and other volunteers.
+          You'll also
+          learn about all the policies and any training you'll need. You will have ongoing support throughout your
+          volunteering
+          journey.
+        </p>
+        <div>
+        </div>
+
+  </main>
+
+  </fieldset>
+
+</div>
+
+</form>
+</div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{% endblock %}


### PR DESCRIPTION
Restores /v19/application/submitted-v3-equality-removed, which returned Not found after the page was renamed to submitted.html in the July baseline. The restored copy matches the current submitted.html, so it keeps the layout and back link fixes. Existing shared links for devs now resolve again.