### PR TITLE
Add beta banner to all layouts so it shows on every page

### DIFF
--- a/app/views/layout_login.html
+++ b/app/views/layout_login.html
@@ -21,6 +21,15 @@ NHS Volunteering
 <!-- Header code examples can be found at https://service-manual.nhs.uk/design-system/components/header -->
 {% block header %}
 <header></header>
+
+<div class="beta-banner" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 {% endblock %}
 
 <!-- Edit the footer -->

--- a/app/views/layout_vol_header-no-footer-links.html
+++ b/app/views/layout_vol_header-no-footer-links.html
@@ -43,7 +43,13 @@ NHS Volunteering
 </header>
 
 
-<div class="nhsuk-u-margin-bottom-7" aria-label="header" role="complementary">
+<div class="beta-banner nhsuk-u-margin-bottom-7" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
 </div>
 {% endblock %}
 

--- a/app/views/layout_vol_header.html
+++ b/app/views/layout_vol_header.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
 {% block header %}
 <header class="nhsuk-header" role="banner">
-  <div class="nhsuk-width-container nhsuk-header__container nhsuk-u-margin-bottom-7">
+  <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo">
       <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
         <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40"
@@ -41,6 +41,15 @@ NHS Volunteering
   </div>
 
 </header>
+
+<div class="beta-banner nhsuk-u-margin-bottom-7" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 
 {% endblock %}
 

--- a/app/views/layout_vol_header_nhs_login_2.html
+++ b/app/views/layout_vol_header_nhs_login_2.html
@@ -22,7 +22,7 @@
 <!-- Header code examples can be found at https://service-manual.nhs.uk/design-system/components/header -->
 {% block header %}
 <header class="nhsuk-header" role="banner">
-  <div class="nhsuk-width-container nhsuk-header__container nhsuk-u-margin-bottom-7">
+  <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo">
       <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
         <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
@@ -54,6 +54,15 @@
   </div>
   
 </header>
+
+<div class="beta-banner nhsuk-u-margin-bottom-7" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 {% endblock %}
 
 <!-- Edit the footer -->

--- a/app/views/layout_vol_header_recruiter.html
+++ b/app/views/layout_vol_header_recruiter.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
 {% block header %}
 <header class="nhsuk-header" role="banner">
-  <div class="nhsuk-width-container nhsuk-header__container nhsuk-u-margin-bottom-7">
+  <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo">
       <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
         <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40"
@@ -41,6 +41,15 @@ NHS Volunteering
   </div>
 
 </header>
+
+<div class="beta-banner nhsuk-u-margin-bottom-7" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 
 {% endblock %}
 

--- a/app/views/layout_vol_header_service_maintenance.html
+++ b/app/views/layout_vol_header_service_maintenance.html
@@ -38,6 +38,15 @@
   </div>
   
 </header>
+
+<div class="beta-banner" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 {% endblock %}
 
 <!-- Edit the footer -->

--- a/app/views/v25/v25_layout_vol_header.html
+++ b/app/views/v25/v25_layout_vol_header.html
@@ -23,7 +23,7 @@ NHS Volunteering
 
 {% block header %}
 <header class="nhsuk-header" role="banner">
-  <div class="nhsuk-width-container nhsuk-header__container nhsuk-u-margin-bottom-7">
+  <div class="nhsuk-width-container nhsuk-header__container">
     <div class="nhsuk-header__logo">
       <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
         <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40"
@@ -41,6 +41,15 @@ NHS Volunteering
   </div>
 
 </header>
+
+<div class="beta-banner nhsuk-u-margin-bottom-7" aria-label="beta-banner" role="complementary">
+  <div class="nhsuk-width-container ">
+    <strong class="nhsuk-tag">BETA</strong>
+    <span>Give your feedback to help us improve this service. <a
+        href="https://online1.snapsurveys.com/NHSVolunteeringBetaFeedback" target="_blank"
+        rel="noopener noreferrer">Take our survey (opens in a new tab).</a></span>
+  </div>
+</div>
 
 {% endblock %}
 


### PR DESCRIPTION
The beta banner (NVPB-3436) was only present in some layouts, so most of the prototype including the r20 recruiter journey, BSA Admin and 132 v25 pages rendered without it.

Changes:
- Added the existing banner markup (same wording, survey link and styles as layout.html) to the seven layouts that lacked it: layout_vol_header, v25_layout_vol_header, layout_login, layout_vol_header_recruiter, layout_vol_header-no-footer-links, layout_vol_header_nhs_login_2 and layout_vol_header_service_maintenance.
- Moved nhsuk-u-margin-bottom-7 from the header container onto the banner in the four layouts that had it, so the banner sits flush under the header with page spacing unchanged.

Verified in headless Chrome across homepage, r20, v25, BSA Admin, login and service maintenance pages: one banner per page, flush under the header.